### PR TITLE
Add Toprank to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,7 @@ This is a comprehensive and organized collection of directories, tools, learning
 - **[Maxim AI](https://www.getmaxim.ai/)**: A generative AI evaluation and observability platform, empowering modern AI teams to ship products with quality, reliability, and speed.
 - **[Wordware](https://www.wordware.ai)**: A web-hosted IDE where non-technical domain experts work with AI Engineers to build task-specific AI agents. It approaches prompting as a new programming language rather than low/no-code blocks.
 - **[CodeRabbit](https://coderabbit.ai/)**: An AI-powered code review tool that helps developers improve code quality and productivity.
+- **[Toprank](https://github.com/nowork-studio/toprank)**: Open-source MIT Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to ship fixes such as meta tag rewrites, JSON-LD schema generation, keyword bid adjustments, and CMS content pushes.
 - **[Pagerly](https://www.pagerly.io)**: Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.
 - **[Hexabot](https://hexabot.ai)**: A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
 - **[Plandex](https://github.com/plandex-ai/plandex)**: Open source, terminal-based AI programming engine for complex tasks.


### PR DESCRIPTION
## Summary
- add Toprank to `README.md` under `### Developer Tools`
- keep the existing Markdown bullet-list style used in that section
- place it alongside other developer-facing AI workflow tools

## Why Toprank fits
Toprank is an open-source MIT Claude Code plugin with 9 SEO and Google Ads skills. It is actively maintained, has 100+ GitHub stars, and extends developer workflows with practical search and ads automation.

It connects Google Search Console, PageSpeed Insights, and the Google Ads API, and can ship fixes such as meta tag rewrites, JSON-LD schema generation, keyword bid adjustments, and CMS content pushes.

This repository does not have a dedicated `Developer Productivity Tools` subsection, so I placed Toprank in `### Developer Tools`, the closest existing category for a Claude Code workflow plugin.
