### PR TITLE
Add NotFair under Marketing & Sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,6 +901,7 @@ This is a comprehensive and organized collection of directories, tools, learning
 - **[Canva Magic Studio](https://canva.com)**: Complete AI-powered design suite.
 - **[InVideo AI](https://invideo.io)**: Create social media videos from a simple script.
 - **[Brandmark](https://brandmark.io/)**: Professional logo and branding generator with AI.
+- **[NotFair](https://notfair.co/)**: Hosted Google Ads MCP server connecting Claude and other AI agents to a Google Ads account; diagnose performance, recommend optimizations, and execute approved changes.
 
 ### E-commerce & Retail
 - **[Klaviyo (AI)](https://klaviyo.com)**: Predictive marketing and sales automation for online stores.


### PR DESCRIPTION
Adding NotFair under Marketing & Sales.

NotFair is a hosted Google Ads MCP server that connects Claude and other AI agents (Cursor, etc.) to a Google Ads account. It can diagnose campaign performance (CPA, ROAS, search-term waste, quality scores), recommend optimizations (bids, budgets, negative keywords, ad copy), and execute approved changes via the Google Ads API with a built-in human-approval gate. Free tier available.

Linked to the product page since there's no public source repo, similar to other entries in this section like Jasper AI, Adzooma, and Phrasee.

Happy to adjust the wording if you'd prefer.