### PR TITLE
Add AIServices — 29-service x402 API platform for AI agents (MCP Server/Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ This is a comprehensive and organized collection of directories, tools, learning
 - **[MCP Market](https://mcpmarket.com/)**: Marketplace for MCP-related tools and services.
 - **[Cursor MCP Directory](https://cursor.directory/mcp)**: Directory of MCP servers and tools curated by Cursor.
 - **[VSCode MCP Directory](https://code.visualstudio.com/mcp)**: Official VSCode directory for MCP servers and integrations.
+- **[AIServices](https://aiservices.to)**: 29-service API platform for AI agents — crypto market data, DeFi yields, whale tracking, and dispute resolution. MCP endpoint with x402 micropayments on Base.
 - **[Claude MCP Servers](https://www.claudemcp.com/servers)**: Claude's curated list of MCP servers.
 - **[PulseMCP Server Directory](https://www.pulsemcp.com/servers)**: Large, frequently updated directory of MCP servers, including trending, official, and community servers across many.
 - **[MCPServers.Net](https://mcpservers.net/)**: Comprehensive MCP server navigation platform, featuring official and community servers, tutorials, and resources.


### PR DESCRIPTION
## AIServices — Paid APIs for AI Agents

Added **[AIServices](https://aiservices.to)** to the **MCP Server/Tools** section.

### What is it?
A 29-service API platform for AI agents with built-in x402 micropayments on Base L2. Provides crypto market data, DeFi yields, whale tracking, exchange flows, dispute resolution, and more.

### Key features:
- **29 endpoints**: 11 free + 4 x402 paid + dispute resolution
- **MCP endpoint**: `/mcp` with 8 tools (remote MCP transport via SSE)
- **Published on MCP Registry**: `to.aiservices/aiservices`
- **x402 payments**: Native micropayments ($0.01-$0.05/call) via USDC on Base
- **Dispute resolution**: Policy-driven resolution engine with 7 templates

### Links:
- API: https://api.aiservices.to
- Docs: https://aiservices.to
- GitHub: https://github.com/vbkotecha/aiservices-api
- MCP Registry: to.aiservices/aiservices

The entry fits naturally in MCP Server/Tools as AIServices provides a remote MCP endpoint.