### PR TITLE
Add Hermes to AI Agents & Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,6 +946,7 @@ This is a comprehensive and organized collection of directories, tools, learning
 ### AI Agents & Frameworks
 - **[AutoGPT](https://agpt.co)**: One of the first and most powerful open-source autonomous agents.
 - **[SuperAGI](https://superagi.com)**: Infrastructure to build, manage, and deploy AI agents.
+- **[Hermes](https://buildwithhermes.com)**: Operating platform for AI voice agencies. Deploy and manage phone voice agents with built-in CRM, campaign orchestration, and white-label client workspaces.
 - **[n8n AI](https://n8n.io)**: Workflow automation with native AI nodes.
 - **[Dify](https://dify.ai)**: LLM App Development platform to easily create agents and RAG.
 - **[Manus](https://manus.im)**: The "Action Engine". A general agent capable of executing complex tasks, navigating, and automating complete workflows.

--- a/README.md
+++ b/README.md
@@ -946,7 +946,7 @@ This is a comprehensive and organized collection of directories, tools, learning
 ### AI Agents & Frameworks
 - **[AutoGPT](https://agpt.co)**: One of the first and most powerful open-source autonomous agents.
 - **[SuperAGI](https://superagi.com)**: Infrastructure to build, manage, and deploy AI agents.
-- **[Hermes](https://buildwithhermes.com)**: Operating platform for AI voice agencies. Deploy and manage phone voice agents with built-in CRM, campaign orchestration, and white-label client workspaces.
+- **[Hermes](https://buildwithhermes.com)**: Operating platform for AI voice agencies with white-label client workspaces, CRM, and campaign orchestration.
 - **[n8n AI](https://n8n.io)**: Workflow automation with native AI nodes.
 - **[Dify](https://dify.ai)**: LLM App Development platform to easily create agents and RAG.
 - **[Manus](https://manus.im)**: The "Action Engine". A general agent capable of executing complex tasks, navigating, and automating complete workflows.


### PR DESCRIPTION
## What this adds

Hermes (https://buildwithhermes.com) under **AI Agents & Frameworks**, next to SuperAGI since both are infrastructure for deploying and managing agents.

## Why it fits

The section covers platforms for building and operating AI agents. Hermes is the operating layer for phone-based voice agents: agencies deploy agents, run inbound/outbound call campaigns, and manage contacts through a built-in CRM, all under their own brand. It complements the existing entries, which focus on general-purpose or search agents, by covering the voice/telephony agent category that is not yet represented in this subsection.

Entry follows the existing format (bold link + one-line description). Happy to adjust wording or placement.