### PR TITLE
Add AISOTools to General AI Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ This is a comprehensive and organized collection of directories, tools, learning
 - **[AI Scout](https://aiscout.net/)** : AI Tools Directory
 - **[AI Search Visibility & Optimization Tools](https://www.aeotools.space)** : Directory of AI Search Visibility & Optimization Tools
 - **[AI Sites Net](https://ai-sites.net/)** : Chinese AI Tools Directory
+- **[AISOTools](https://aisotools.com)**: Directory of AI tools with search, comparison, and AI-search visibility monitoring for makers.
 - **[AI Tools Arena](https://aitoolsarena.com/)** : Your Ultimate Resource for AI Tools and Insights
 - **[AI Tools Corner](https://aitoolscorner.com/)** : Collection of best AI Tools,
 - **[AI Tools Directory](https://aidirectory.wiki/)** : Curated list of AI tools


### PR DESCRIPTION
Adds **AISOTools** (https://aisotools.com) to `AI Directories by Category → General AI Directories`.

```
- **[AISOTools](https://aisotools.com)**: Directory of AI tools with search, comparison, and AI-search visibility monitoring for makers.
```

**Disclosure:** I operate this site. Happy to close if self-submissions aren't wanted here.

### Why this section
It is a browsable AI-tools directory (search, categories, side-by-side comparison, alternatives), so it belongs with the other directory entries rather than in a tool section. The closest existing neighbour is `AI Search Visibility & Optimization Tools`, listed two lines above — same category, different site.

### Verification run before opening this PR
```
$ curl -sI -A "Mozilla/5.0" https://aisotools.com/   ->  200
$ curl -s https://aisotools.com/api/mcp -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
    "params":{"name":"list_ai_tool_categories","arguments":{}}}'
  -> {"totalTools": 1187, "categories": [...]}
```
The catalog count is deliberately left out of the description because it changes weekly and would go stale in the file.

### Checklist
- [x] One tool per PR — this adds exactly one line
- [x] Format matches the spec: `- **[Name](url)**: sentence.` — 94-character description, ends with a period
- [x] URL is clean — no `?ref=`, no UTM, no shortener, no trailing slash
- [x] No affiliate links anywhere on the linked page's directory listings
- [x] Neutral wording — no "best", "revolutionary", "ultimate"
- [x] Not a duplicate — searched the README for `aisotools` and `AISO`, zero hits
- [x] Publicly available and usable, no waitlist or beta gate
- [x] Alphabetical within the section (`ai-sites-net` < `aisotools` < `ai-tools-arena`)
- [x] LF preserved — the committed `README.md` blob is CRLF, so I suppressed local `*.md` normalization to keep the diff at **+1 line** instead of rewriting all 1,018 lines. Worth knowing: the blob predates `.gitattributes`, so any contributor whose editor obeys `eol=lf` will produce an unreviewable full-file diff. Say the word and I'll open a separate normalization PR.
- [x] Not link-farming — this is one of two submissions this week, not a mass send