### PR TITLE
Add Fortuneteller.Today to Chatbots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,8 @@ This is a comprehensive and organized collection of directories, tools, learning
 - **[DeepSeek-R1](https://www.deepseek.com)**: A versatile AI assistant by DeepSeek, designed for conversational interactions, code generation, and creative tasks.
 - **[dmwithme](https://dmwithme.com)**: AI companion with realistic emotions that can disagree, get moody, and challenge you.
 
+- **[Fortuneteller.Today](https://www.fortuneteller.today)**: AI assistant for tarot, astrology, numerology, BaZi, and rune readings.
+
 ### Search & Research Tools
 - **[Kazimir.ai](https://kazimir.ai/)**: A search engine designed to search AI-generated images.
 - **[Perplexity AI](https://www.perplexity.ai/)**: AI powered search tools.


### PR DESCRIPTION
## Summary
- Adds Fortuneteller.Today to the Chatbots & Conversational AI section.

## Checklist
- One tool in this PR
- Entry uses the requested markdown format
- URL is direct and has no tracking parameters
- Description is factual, neutral, under 120 characters, and ends with a period
- Website returns HTTP 200
- Tool uses AI for tarot, astrology, numerology, BaZi, and rune readings