### PR TITLE
Add SaaSCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ For cross-provider comparisons, consult independent benchmark methodologies in a
 - **[AI Tools Submit](https://submitaitools.org/submit-your-ai-tool/)**: Submit your AI tools
 - **[Awesome AI Tools](https://github.com/mahseema/awesome-ai-tools)**: A curated list of Artificial Intelligence Top Tools
 - **[AIDir](https://aidir.wiki)**: The first AI Directory of the world, Since 2022!
+- **[SaaSCity](https://saascity.io)**: Gamified SaaS and AI directory where every listing becomes a building on an isometric city map
 - **[AI Directory](https://aidirectory.wiki)**: Curated collection of AI-powered tools for productivity, creativity, and business.
 - **[AiDirs](https://aidirs.best)**: Discover and Share the Best AI Tools
 - **[AI For Developers](https://aifordevelopers.org)**: A curated list of AI DevTools


### PR DESCRIPTION
Adding SaaSCity to the list.

**[SaaSCity](https://saascity.io)** — a SaaS and AI product directory built as an isometric 3D city: every listing becomes a building on a live map instead of a row in a table. DR 59, dofollow listing pages, free submission queue with a paid skip-the-line option.

Single-line addition, placed in the section that fit best and matching the surrounding format. Happy to move or reword it if you would rather have it elsewhere.

https://claude.ai/code/session_01Q5fe2WDywQtBgHnQ8PXr5m