### PR TITLE
Add YYLO to AI Code Assistants & Editors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ For cross-provider comparisons, consult independent benchmark methodologies in a
 - **[Replit Agent](https://replit.com/agent)**: Advanced AI agent within Replit that builds complete applications from natural language descriptions.
 - **[Devin AI](https://devin.ai/)**: An autonomous AI software engineer that can plan, code, debug, and deploy projects end-to-end.
 - **[Qoder](https://qoder.com/)**: Agentic Coding Platform for Real Software Think Deeper. Build Better.
+- **[YYLO](https://github.com/yylo-dev/yylo)**: Command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries.
 
 ### Code Completion & Autocompletion
 - **[GitHub Copilot](https://github.com/features/copilot)**: AI-driven code completion tool for real-time suggestions in IDEs.


### PR DESCRIPTION
## Tool Being Added

- **Tool Name**: YYLO
- **URL**: https://github.com/yylo-dev/yylo
- **Section**: 🛠️ Development & Coding Tools → AI Code Assistants & Editors

## Entry as It Appears in the README

```markdown
- **[YYLO](https://github.com/yylo-dev/yylo)**: Command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries.
```

## Verification Checklist

- [x] One tool per PR (or one logical change)
- [x] Entry uses the exact format: `- **[Name](URL)**: Description.`
- [x] URL has no trailing slash (unless the site requires it)
- [x] URL has no UTM, referral, or tracking parameters
- [x] Description is ≤120 characters and ends with a period
- [x] Description is factual and neutral (no marketing language)
- [x] File uses LF line endings (check editor status bar)
- [x] Tool is not already listed in the README (searched first)
- [x] URL returns HTTP 200 (the tool's website loads)
- [x] Tool is AI-powered
- [x] PR title is descriptive (e.g., `Add ToolName to Category section`)

## Why Does This Tool Belong in This Section?

YYLO is a command-line orchestrator that runs AI coding agents (Pi and Codex subagents) end to end: it creates a dedicated branch/worktree per task and enforces typed task, validation, merge, and release-readiness boundaries — the same coding-agent band as Aider, Devin AI, and Magic in this section. It is MIT-licensed (57★), installable from npm as `@yylo/cli`, and actively maintained.

## Disclosure

I'm part of the YYLO team — this is a self-submission of our own open-source tool, and this PR was prepared with an AI coding agent and reviewed by me before submission. Every description phrase is quoted from the project's README. Happy to adjust wording or placement (e.g., a different subsection) if you prefer.
